### PR TITLE
Use GPU(0) if it is available

### DIFF
--- a/main
+++ b/main
@@ -7,10 +7,19 @@ set -e
 
 input=$(jq -r .t1 config.json)
 
-singularity run --nv -e docker://anibalsolon/hd-bet:v0.0.1 hd-bet \
+#pick cpu v.s. nvidia gpu
+device=cpu
+nvopts=""
+if hash nvidia-smi; then
+    #TODO - pick an appropriate device instead of 0
+    device=0 
+    nvopts="--nv"
+fi
+
+time singularity run $nvopts -e docker://anibalsolon/hd-bet:v0.0.1 hd-bet \
     -i $input \
     -o masked.nii.gz \
-    -device cpu \
+    -device $device \
     -mode fast \
     -tta 0
 


### PR DESCRIPTION
This code allows HD-BET to use GPU if it's available. We need a better device to pick the correct GPU device if there are more than 1 available. 